### PR TITLE
Nongreedy {% raw %}

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,12 +1,15 @@
 module Liquid
   class Raw < Block
+    FullTokenPossiblyInvalid = /^(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/o
+
     def parse(tokens)
       @nodelist ||= []
       @nodelist.clear
 
       while token = tokens.shift
-        if token =~ FullToken
-          if block_delimiter == $1
+        if token =~ FullTokenPossiblyInvalid
+          @nodelist << $1 if $1 != ""
+          if block_delimiter == $2
             end_tag
             return
           end
@@ -18,4 +21,3 @@ module Liquid
 
   Template.register_tag('raw', Raw)
 end
-

--- a/test/liquid/tags/raw_tag_test.rb
+++ b/test/liquid/tags/raw_tag_test.rb
@@ -9,7 +9,20 @@ class RawTagTest < Test::Unit::TestCase
   end
 
   def test_output_in_raw
-    assert_template_result '{{ test }}',
-                           '{% raw %}{{ test }}{% endraw %}'
+    assert_template_result '{{ test }}', '{% raw %}{{ test }}{% endraw %}'
+  end
+
+  def test_open_tag_in_raw
+    assert_template_result ' Foobar {% invalid ', '{% raw %} Foobar {% invalid {% endraw %}'
+    assert_template_result ' Foobar invalid %} ', '{% raw %} Foobar invalid %} {% endraw %}'
+    assert_template_result ' Foobar {{ invalid ', '{% raw %} Foobar {{ invalid {% endraw %}'
+    assert_template_result ' Foobar invalid }} ', '{% raw %} Foobar invalid }} {% endraw %}'
+    assert_template_result ' Foobar {% invalid {% {% endraw ', '{% raw %} Foobar {% invalid {% {% endraw {% endraw %}'
+    assert_template_result ' Foobar {% {% {% ', '{% raw %} Foobar {% {% {% {% endraw %}'
+    assert_template_result ' test {% raw %} {% endraw %}', '{% raw %} test {% raw %} {% {% endraw %}endraw %}'
+  end
+
+  def test_raw_is_not_greedy
+    assert_template_result ' {{Foo}}   {{Bar}} ', '{% raw %} {{Foo}} {% endraw %} {% raw %} {{Bar}} {% endraw %}'
   end
 end


### PR DESCRIPTION
While helping Bill with his mission of eliminating the need to use zapier for things within Customer.io, we stumbled on the following issue:

A webhook action (which hits our beta API) has a body template with the content:
```{"name":"local_currency_filter_range", "value":"{% raw %}{% case customer.local_currency %}{% when \"CAD\" %}{% assign cvr = {% endraw %}{{ customer.currency_cad}} {% raw %} %}{% assign symbol = \"$\" %}{% endcase %}{% endraw %}"}```

This renders as:
```{"name":"local_currency_filter_range", "value":"{% case customer.local_currency %}{% when \"CAD\" %}{% assign cvr = {% endraw %}{{ customer.currency_cad}} {% raw %} %}{% assign symbol = \"$\" %}{% endcase %}"}```

And the response from our beta API is:
```{"errors":[{"detail":"Invalid liquid code in value: case tag was never closed","source":{"pointer":"/data/attributes/value"},"status":"422"}]}```

What's happening here is we have multiple `{% raw %}` blocks in the body, and when rendering `{% raw %}` blocks, liquid is being greedy, and treating everything between the first `raw` tag and the last `endraw` tag as... raw.

Ended up finding this issue in Shopify's liquid repo describing the problem: https://github.com/Shopify/liquid/issues/280

Which lead us to this change https://github.com/Shopify/liquid/commit/c280936afaf73c0ea8889be3ace6d37ee6125f8c

Which we're backporting into our version of liquid here.